### PR TITLE
Add tmux support

### DIFF
--- a/connmgr.py
+++ b/connmgr.py
@@ -39,7 +39,7 @@ import sys
 
 VERSION = '0.7.4'
 
-supportedTerms = ["Gnome Terminal", "Terminator", "Guake"]
+supportedTerms = ["Gnome Terminal", "Terminator", "Guake", "TMux"]
 
 # TreeStore object:
 # Type, Name, Host, Profile, Protocol

--- a/terminals.js
+++ b/terminals.js
@@ -17,7 +17,7 @@
 //   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // Supported terminals. This terminal list must match as in connmgr.py
-const TERMINALS = new Array("gnome-terminal", "terminator", "guake");
+const TERMINALS = new Array("gnome-terminal", "terminator", "guake", "tmux");
 
 
 // ******************************************************
@@ -34,6 +34,9 @@ function TerminalCommand(terminal) {
             break;
         case 2:
             this.resClass = new GuakeCommand(terminal);
+            break;
+        case 3:
+            this.resClass = new TMuxCommand(terminal);
             break;
         default:
             this.resClass = new GnomeTerminalCommand(terminal);
@@ -258,3 +261,37 @@ function GuakeCommand(terminal) {
 }
 
 
+// ******************************************************
+// Tmux class derived from base class
+// ******************************************************
+function TMuxCommand(terminal) {
+    this._init(terminal);
+}
+
+    TMuxCommand.prototype = {
+    __proto__: TerminalCommand.prototype,
+
+    createCmd: function () {
+
+        if (this.child.Type == '__item__') {
+            this._setParams();
+
+            this.command += this.cmdTerm;
+            this.command += ' new-window -n ' + (this.child.Name).quote();
+            this.command += ' ' + (this.sshparams + this.child.Protocol + " " + this.sshparams_noenv).quote();
+        }
+
+        if (this.child.Type == '__app__') {
+
+            if (this.child.Protocol == 'True') {
+                this.command += this.cmdTerm + ' new-window -n ' + (this.child.Name).quote();
+                this.command += ' ' + (this.child.Host).quote();
+            } else {
+                this.command += this.child.Host;
+            }
+        }
+
+        return this.command;
+    }
+
+}


### PR DESCRIPTION
This patch just adds a 'tmux' option which runs tmux new-window. It's a bit limited in its current scope but as I only ever use one session and want names transferred it works perfectly for me.
