### PR TITLE
Portability fix wrt environment

### DIFF
--- a/connmgr.py
+++ b/connmgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #   ConnectionManager 3 - Simple GUI app for Gnome 3 that provides a menu
 #   for initiating SSH/Telnet/Custom Apps connections.

--- a/extension.js
+++ b/extension.js
@@ -111,9 +111,9 @@ ConnectionManager.prototype = {
         let menuPref = new PopupMenu.PopupMenuItem("Connection Manager Settings");
         menuPref.connect('activate', Lang.bind(this, function() {
             try {
-                Util.trySpawnCommandLine('python ' + this._prefFile);
-            } catch (e) {
                 Util.trySpawnCommandLine('python2 ' + this._prefFile);
+            } catch (e) {
+                Util.trySpawnCommandLine('python ' + this._prefFile);
             }
         }));
         this.menu.addMenuItem(menuPref, this.menu.length+1);

--- a/sshmenu2cm.py
+++ b/sshmenu2cm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #   ConnectionManager 3 - a simple script to convert SSHMenu configuration file 
 #   to a CM configuration file.


### PR DESCRIPTION
I'm currently running connectionmanager on my ArchLinux box, with Gnome 3.4.
The initial problem was that python is symlinked to python3 (and most packages rely on this fact).
To alleviate this problem I propose the following commit, in which I turned around your calls to python and python2 and fixed the references to /usr/bin/env python. 

If you have any questions or suggestions, please don't hesitate to ask them.
