### PR TITLE
Add support for systems with Python2 and Python3 installed (e.g. Archlinux)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -104,9 +104,9 @@ const ConnectionManager = new Lang.Class({
         let menuPref = new PopupMenu.PopupMenuItem("Connection Manager Settings");
         menuPref.connect('activate', Lang.bind(this, function() {
             try {
-                Util.trySpawnCommandLine('python ' + this._prefFile);
-            } catch (e) {
                 Util.trySpawnCommandLine('python2 ' + this._prefFile);
+            } catch (e) {
+                Util.trySpawnCommandLine('python ' + this._prefFile);
             }
         }));
         this.menu.addMenuItem(menuPref, this.menu.length+1);


### PR DESCRIPTION
The original behavior was to try invoking `python` first, and then invoke `python2` if that fails.  However, on systems with both Python2 and Python3 installed in parallel where `python` is an alias for `python3` (like Archlinux), the first invocation with `python` seems to succeed, but the script fails.  By simply trying `python2` first, this case can be handled correctly without breaking it on other systems.
